### PR TITLE
Add onReady props

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ React.render(
 </script>
 ```
 
+## Props
+
+### `clientToken`
+The client token used to perform the transaction.
+
+### `onNonceReceived`
 By default, once Drop-In receives a credit card nonce it submits the outer form. To intercept any nonce, use this callback:
 
 ```js
@@ -49,6 +55,14 @@ var nonceReceived = function(event, nonce) {
 <DropIn onNonceReceived={nonceReceived} />
 ```
 
+### `onReady`
+A callback triggered when the DropIn iFrame has been written to the DOM, i.e. it's fully rendered and visible to the user.
+
+### `rootClassName`
+The class name of the outer DOM container.
+*Default*: `__braintree-react__`
+
+## Examples
 View example integrations [here](examples).
 
 ## Notes

--- a/dist/braintree-react-cjs.js
+++ b/dist/braintree-react-cjs.js
@@ -33,7 +33,8 @@ var DropIn = ReactInstance.createClass({
   propTypes: {
     clientToken: ReactInstance.PropTypes.string,
     rootClassName: ReactInstance.PropTypes.string,
-    onNonceReceived: ReactInstance.PropTypes.func
+    onNonceReceived: ReactInstance.PropTypes.func,
+    onReady: ReactInstance.PropTypes.func
   },
 
   getDefaultProps: function () {
@@ -57,7 +58,8 @@ var DropIn = ReactInstance.createClass({
       clientToken,
       'dropin', {
         container: this.getDOMNode(),
-        paymentMethodNonceReceived: this.props.onNonceReceived
+        paymentMethodNonceReceived: this.props.onNonceReceived,
+        onReady: this.props.onReady
       }
     );
   },

--- a/dist/braintree-react.js
+++ b/dist/braintree-react.js
@@ -33,7 +33,8 @@ var DropIn = ReactInstance.createClass({
   propTypes: {
     clientToken: ReactInstance.PropTypes.string,
     rootClassName: ReactInstance.PropTypes.string,
-    onNonceReceived: ReactInstance.PropTypes.func
+    onNonceReceived: ReactInstance.PropTypes.func,
+    onReady: ReactInstance.PropTypes.func
   },
 
   getDefaultProps: function () {
@@ -57,7 +58,8 @@ var DropIn = ReactInstance.createClass({
       clientToken,
       'dropin', {
         container: this.getDOMNode(),
-        paymentMethodNonceReceived: this.props.onNonceReceived
+        paymentMethodNonceReceived: this.props.onNonceReceived,
+        onReady: this.props.onReady
       }
     );
   },

--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -22,7 +22,8 @@ var DropIn = ReactInstance.createClass({
   propTypes: {
     clientToken: ReactInstance.PropTypes.string,
     rootClassName: ReactInstance.PropTypes.string,
-    onNonceReceived: ReactInstance.PropTypes.func
+    onNonceReceived: ReactInstance.PropTypes.func,
+    onReady: ReactInstance.PropTypes.func
   },
 
   getDefaultProps: function () {
@@ -46,7 +47,8 @@ var DropIn = ReactInstance.createClass({
       clientToken,
       'dropin', {
         container: this.getDOMNode(),
-        paymentMethodNonceReceived: this.props.onNonceReceived
+        paymentMethodNonceReceived: this.props.onNonceReceived,
+        onReady: this.props.onReady
       }
     );
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintree-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is passed as the `onReady` callback to the underlying braintree setup.
`onReady` was introduced in braintree-web 2.7.0 (see: https://github.com/braintree/braintree-web/issues/19)
