### PR TITLE
moved braintree-web to primary dependencies & updated to 2.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "react-component"
   ],
   "devDependencies": {
-    "braintree-web": "^2.3.3",
     "browserify": "^8.1.3",
     "express": "^4.11.2",
     "mocha": "^2.1.0",
     "phantom": "^0.7.2",
     "phantomjs": "^1.9.15",
     "react": "^0.12.2"
+  },
+  "dependencies": {
+    "braintree-web": "^2.7.3"
   }
 }


### PR DESCRIPTION
for this react component to work using `npm install braintree-react` install method, `braintree-web` must be a primary dependency in package.json
