### PR TITLE
Prop name fix

### DIFF
--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -54,7 +54,9 @@ const DropIn = React.createClass({
   },
 
   render: function() {
-    return <div className={this.props.rootClassName}></div>;
+    return React.DOM.div({
+      className:this.props.rootClassName
+    });
   }
 
 });

--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -10,7 +10,7 @@ const DropIn = React.createClass({
   propTypes: {
     clientToken: React.PropTypes.string.isRequired,
     rootClassName: React.PropTypes.string,
-    onNonceReceived: React.PropTypes.func,
+    onPaymentMethodReceived: React.PropTypes.func,
     onReady: React.PropTypes.func,
     braintree: React.PropTypes.object.isRequired
   },


### PR DESCRIPTION
A couple of minor fixes:
- In `propTypes` on DropIn, the name hadn't been updated from `onNonceReceived` to `onPaymentMethodReceived`
- The JSX in `render` was unnecessary given the one element of mark-up and was failing to parse without a JSX build step (extra work for users of this lib). So I remove the JSX.
