### PR TITLE
Teardown and Double Load fix

### DIFF
--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -54,7 +54,9 @@ const DropIn = React.createClass({
   },
 
   render: function() {
-    return <div className={this.props.rootClassName}></div>;
+    return React.DOM.div({
+      className:this.props.rootClassName
+    });
   }
 
 });

--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -23,7 +23,8 @@ const DropIn = React.createClass({
 
   getInitialState: function() {
     return  {
-      braintreeInitialized: false
+      braintreeInitialized: false,
+      braintreeCheckout: null
     };
   },
 
@@ -36,21 +37,39 @@ const DropIn = React.createClass({
   },
 
   initializeBraintree: function(props) {
-    props = props || this.props;
-    if (props.braintree && !this.state.braintreeInitialized) {
-      this.setState({
-        braintreeInitialized: true
-      }, function() {
-        props.braintree.setup(
-          this.props.clientToken,
-          'dropin', {
-            container: ReactDOM.findDOMNode(this),
-            onPaymentMethodReceived: this.props.onPaymentMethodReceived,
-            onReady: this.props.onReady
+    if (!props.braintree || this.state.braintreeInitialized) return;
+
+    this.setState({
+      braintreeInitialized: true
+    }, function () {
+      props.braintree.setup(
+        this.props.clientToken,
+        'dropin', {
+          container: ReactDOM.findDOMNode(this),
+          onPaymentMethodReceived: props.onPaymentMethodReceived,
+          onReady: function (checkout) {
+            this.setState({
+                braintreeCheckout: checkout
+              },
+              function() {
+                if (props.onReady) {
+                  props.onReady(checkout);
+                }
+              });
+            }.bind(this)
           }
         );
-      });
-    }
+    });
+  },
+
+  teardownBraintree: function () {
+    if (!this.state.braintreeCheckout) return;
+
+    this.state.braintreeCheckout.teardown(function() {
+      this.setState({
+          braintreeCheckout: null
+        });
+    });
   },
 
   render: function() {

--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -10,7 +10,7 @@ const DropIn = React.createClass({
   propTypes: {
     clientToken: React.PropTypes.string.isRequired,
     rootClassName: React.PropTypes.string,
-    onNonceReceived: React.PropTypes.func,
+    onPaymentMethodReceived: React.PropTypes.func,
     onReady: React.PropTypes.func,
     braintree: React.PropTypes.object.isRequired
   },

--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -32,8 +32,8 @@ const DropIn = React.createClass({
     this.initializeBraintree(this.props);
   },
 
-  componentWillReceiveProps: function(nextProps) {
-    this.initializeBraintree(nextProps);
+  componentWillUnmount: function() {
+    this.teardownBraintree();
   },
 
   initializeBraintree: function(props) {


### PR DESCRIPTION
In this PR I attempted to implement the braintree `teardown` feature (see https://developers.braintreepayments.com/guides/client-sdk/javascript/v2) using `componentWillUnmount` hook.

I also tacked on removal of `componentWillReceiveProps` because it was firing repeatedly in my Redux based app which resulted in multiple instances of the braintree dropin component showing up. See my commit comment on this, there may be a better way but I think it's hard to support this hook correctly here.

Note that this includes the small fix PR #16 (sorry, just hard to test with that bug in there).
