### PR TITLE
replace ES6  with  so don't need transpiler

### DIFF
--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const React = require('react');
-const ReactDOM = require('react-dom');
+var React = require('react');
+var ReactDOM = require('react-dom');
 
-const DropIn = React.createClass({
+var DropIn = React.createClass({
 
   displayName: 'BraintreeDropIn',
 


### PR DESCRIPTION
`const` is ES6 only so will go fine on some browsers but not others unless transpiled.

I found when trying to use my app from an iPhone.
