### PR TITLE
Drop-In container Id instead finding its node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ React.render(
 
 This should be `braintree-web`.
 
+### `containerId`
+
+The Drop-In container id for braintree setup.
+
 ### `clientToken` (required)
 
 The client token used to set up the integration. Learn [how to generate a client token](https://developers.braintreepayments.com/start/hello-server#generate-a-client-token).

--- a/lib/dropin.js
+++ b/lib/dropin.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var React = require('react');
-var ReactDOM = require('react-dom');
 
 var DropIn = React.createClass({
 
   displayName: 'BraintreeDropIn',
 
   propTypes: {
+    containerId: React.PropTypes.string,
     clientToken: React.PropTypes.string.isRequired,
     rootClassName: React.PropTypes.string,
     onPaymentMethodReceived: React.PropTypes.func,
@@ -17,7 +17,8 @@ var DropIn = React.createClass({
 
   getDefaultProps: function () {
     return {
-      rootClassName: '__braintree-react__'
+      containerId: 'braintree-react-drop-in',
+      rootClassName: '__braintree-react__',
     };
   },
 
@@ -45,7 +46,7 @@ var DropIn = React.createClass({
       props.braintree.setup(
         this.props.clientToken,
         'dropin', {
-          container: ReactDOM.findDOMNode(this),
+          container: props.containerId,
           onPaymentMethodReceived: props.onPaymentMethodReceived,
           onReady: function (checkout) {
             this.setState({
@@ -74,10 +75,10 @@ var DropIn = React.createClass({
 
   render: function() {
     return React.DOM.div({
-      className:this.props.rootClassName
+      id: this.props.containerId,
+      className: this.props.rootClassName
     });
   }
-
 });
 
 module.exports = DropIn;

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "react-component"
   ],
   "dependencies": {
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2"
+    "react": "^0.13.0"
   },
   "devDependencies": {
     "babel-jest": "^6.0.1",


### PR DESCRIPTION
As reported in [braintree js reference documentation](https://developers.braintreepayments.com/reference/client-reference/javascript-v2-reference#configuration) in the setup configuration the `container` key should be the id of the `container`, not his `DOM` node.

I added a default `containerId` prop and updated the `README.md` file.
Let me know if I need to improve my pr.
