### PR TITLE
specify react 15.1 in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
     "react-component"
   ],
   "dependencies": {
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2"
+    "react": "^15.1.0",
+    "react-dom": "^15.1.0"
   },
   "devDependencies": {
-    "babel-jest": "^6.0.1",
+    "babel-jest": "^12.1.0",
     "babel-preset-es2015": "*",
     "babel-preset-react": "*",
     "braintree-web": "^2.9.0",
     "browserify": "^12.0.1",
     "express": "^4.11.2",
-    "jest-cli": "^0.8.0",
-    "react-addons-test-utils": "^0.14.2",
+    "jest-cli": "^12.1.1",
+    "react-addons-test-utils": "^15.1.0",
     "reactify": "^1.1.1",
     "standard": "^7.0.1"
   },


### PR DESCRIPTION
I'm not sure if there is a better way to do this, but if the version of react in `dependencies` doesn't match the one being used, you can get some weird issues. In my case it was complaining about two different versions of React mucking with the DOM.

I've upgraded the dependency to 15.1 and upgraded jest as well (the old version broke).

Sorry for not catching it before. I did a local path[1] in my project this time to make sure the package works properly, sorry I didn't do this the first time.

[1] https://docs.npmjs.com/files/package.json#local-paths
